### PR TITLE
Allow users to have unrandomized widgets.

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -9,7 +9,7 @@ $(function() {
         self.url = 'http://www.humblebundle.com/store/product/'
 
         // Shuffle the games
-        games = _.shuffle(games)
+        if(window.location.hash != "#unrandomized") games = _.shuffle(games)
 
         // Initialized methods
         self.renderFilters()


### PR DESCRIPTION
If the user adds #sorted hash to the end of the url, the games list
won't be randomized. They won't be sorted, but they will appear in the
same order they're in in the file. This is a silent action--users have
to already know about this to use it.

Reason: I've had several people PM me on steam complaining that the list
is randomized. I see no problem with this, as it helps you find out
about different games. However, I can also see it annoying someone
looking through the entire list. Since I'm unwilling to make changes
that affect things you've done, I've told people to submit an issue if
they don't like it. In the meantime, they can use this to not have the
list sorted.
