### PR TITLE
various changes to table view, add timestamp to json.

### DIFF
--- a/json.html
+++ b/json.html
@@ -1,10 +1,10 @@
 
 <html>
 <head>
-	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <style>
 body, #form-preview {
-  background: url(http://calvein.github.io/humble-games/img/bg.png);
+  background: url(http://calvein.github.io/humble-games/images/bg.png);
   color: rgba(255, 255, 255, .8);
   text-shadow: 0 2px 4px hsla(0, 0%, 0%, 0.4);
   padding: 20px;
@@ -121,7 +121,7 @@ function generate() {
 	var devurl = document.getElementById("devurl").value;
 	var myJSON = generatejson(devurl,extras,review,steamurl,desuraurl,name,url,price,description,developer,android,linux,windows,mac,audio,steam,desura,GOG,drmfree,notes);
 	var myWiki = generatewiki(name,url,price,description,developer,android,linux,windows,mac,audio,steam,desura,GOG,drmfree,notes);
-	document.getElementById('json').textContent=JSON.stringify(myJSON,null,4) + ",";
+	document.getElementById('json').textContent=JSON.stringify(myJSON,null,4) + ",\r\n";
 	document.getElementById('wiki').innerText=myWiki;
     return false;
 }
@@ -164,7 +164,8 @@ function generatejson(devurl,extras,review,steamurl,desuraurl,name,url,price,des
 	myGame.URL = myURLs;
 	myGame["notes"]=jescape(notes);
 	myGame["extras"]=extras;
-    return myGame;
+	myGame["timestamp"]=new Date().getTime())
+	return myGame;
 }
 function jescape(unescapedstring) {
 	var escapedstring = unescapedstring.replace(/\\n/g, "\\n").replace(/\\'/g, "\\'").replace(/\\"/g, "\\\"").replace(/\\&/g, "\\&").replace(/\\r/g, "\\r").replace(/\\t/g, "\\t").replace(/\\b/g, "\\b").replace(/\\f/g, "\\f");
@@ -249,7 +250,7 @@ function selectText(containerid) {
   </div>
   <div>
     <label data-key="developer">Notes <span class="required"></span></label>
-    <textarea id="notes" type="text" name="notes" onkeyup="generate();" placeholder="here, tell us about any other forms of DRM or distributors available, the publisher's website, the game release date, etc. Also tell us if the game is a preorder. A couple linebreaks are ok for Calvein's, but not for PCGamingWiki. Keep this short."></textarea>
+    <textarea id="notes" type="text" name="notes" onkeyup="generate();" placeholder="here, tell us about any other forms of DRM or distributors available, the publisher's website, the game release date, etc. Also tell us if the game is a preorder. A couple linebreaks are ok for Calvein's, but not for PCGamingWiki. Keep this short. A timestamp is added to the json automatically if you use this form."></textarea>
   </div>
   <h1>Results</h1>
     <div>JSON for the <a href="http://calvein.github.com/humble-games">list</a><br><pre id="json" onclick="selectText('json');">

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -9,7 +9,7 @@ $(function() {
         self.url = 'http://www.humblebundle.com/store/product/'
 
         // Shuffle the games
-        if(window.location.hash != "#unrandomized") games = _.shuffle(games)
+        games = _.shuffle(games)
 
         // Initialized methods
         self.renderFilters()

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -9,7 +9,7 @@ $(function() {
         self.url = 'http://www.humblebundle.com/store/product/'
 
         // Shuffle the games
-        games = _.shuffle(games)
+        if(window.location.hash != "#unrandomized") games = _.shuffle(games)
 
         // Initialized methods
         self.renderFilters()

--- a/table.html
+++ b/table.html
@@ -201,11 +201,6 @@
 </head>
 <body>
     <div align="center">
-    <!--<br><br><br><br><br>
-    <h1>Table view is <i>broken</i></h1>
-    <h3>Please use the <a href="/humble-games"><i></i>original frame view</i></a> until it is fixed.</h3>
-    <h5>(The game title, developer, and price will still display correctly, but links, DRM, platform, and sorting are broken)<br></h5>
-    <br><br><br><br><br><br><br><br><br><br>-->
     <h1>All games from <a href="http://humblebundle.com">the Humble Store</a></h1>
     <p>All your games are stored on your <a href="https://www.humblebundle.com/home">Humble Bundle account</a>. Feel free to <a href="https://github.com/calvein/humble-games/json.html">edit this list</a>.</p>
     <input autofocus placeholder="e.g: &quot;Trine&quot;">

--- a/table.html
+++ b/table.html
@@ -39,7 +39,7 @@
         vertical-align:middle
     }
 
-    .tdnum, .tdprice, .tdplatform, .tddrm, .tdost, .tdreview {
+    .tdnum, .tdprice, .tdplatform, .tddrm, .tdost, .tdreview, .tddate {
         text-align: center;
     }
 
@@ -173,7 +173,7 @@
 		max-height: 16px;
 	}
 	
-	.tdnotes {
+	.tdnotes, .tddate {
 		display: none;
 	}
     </style>
@@ -223,6 +223,7 @@
         <th id="th_gog" class="th_icon tddrm"><span class="gog"></span></th>
         <th id="th_drmfree" class="th_icon tddrm"><span class="drmfree"></span></th>
         <th id="th_ost" class="th_icon"><span class="ost"></span></th>
+        <th id="th_date" class="tddate">Date Added</th>
         <th id="th_review" class="sorttable_alpha tdreview">Review</th>
         <th id="th_date" class="tdnotes">Notes</th>
         <th id="th_dev" class="sorttable_alpha tddev">Developer</th>
@@ -232,6 +233,7 @@
 	<p>Toggle: <a href="#" onclick="$('.tdnum').toggle();return false;">#</a>, 
 	<a href="#" onclick="$('.tdplatform').toggle();return false;">Platforms</a>, 
 	<a href="#" onclick="$('.tddrm').toggle();return false;">DRMs</a>, 
+	<a href="#" onclick="$('.tddate').toggle();return false;">Date Added</a>, 
 	<a href="#" onclick="$('.tdreview').toggle();return false;">Reviews</a>, 
 	<a href="#" onclick="$('.tddev').toggle();return false;">Developer</a>, 
 	<a href="#" onclick="$('.tddesc').toggle();return false;">Description</a>, 
@@ -271,6 +273,7 @@
             tr.dataset.gog = game.drm.GOG
             tr.dataset.drmfree = game["drm"]["drm-free"]
             tr.dataset.extras = game.extras
+            tr.dataset.timestamp = game.timestamp;
             if(returnIfExist(game.URL) != null) {
                 tr.dataset.reviewurl = returnIfExist(game.URL.review)
                 tr.dataset.devurl = returnIfExist(game.URL.developer)
@@ -400,7 +403,21 @@
                 tdost.appendChild(tdostbg);
             tr.appendChild(tdost);
 
-            var tdreview = document.createElement('td');
+            var tddate = document.createElement('td');
+				tddate.className = 'tddate';
+				if(tr.dataset.timestamp=="undefined") {
+					tddate.setAttribute('sorttable_customkey', "1200000000000");
+					var datestring = "";
+				} else {
+					tddate.setAttribute('sorttable_customkey', tr.dataset.timestamp);
+					var date = new Date(parseInt(tr.dataset.timestamp));
+					var datestring = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][date.getMonth()]+" "
+						+ date.getDate() + ", " + date.getFullYear();
+				}
+				tddate.textContent = datestring;
+			tr.appendChild(tddate);
+			
+			var tdreview = document.createElement('td');
                 tdreview.className = 'tdreview';
 				tdreview.setAttribute('sorttable_customkey', "1");
                 var tdreviewsearchlink = document.createElement('a');

--- a/table.html
+++ b/table.html
@@ -209,6 +209,14 @@
     <p>All your games are stored on your <a href="https://www.humblebundle.com/home">Humble Bundle account</a>. Feel free to <a href="https://github.com/calvein/humble-games/json.html">edit this list</a>.</p>
     <input autofocus placeholder="e.g: &quot;Trine&quot;">
     <p><a href="index.html">Original view with frames</a></p>
+	<p>Toggle: <a href="#" onclick="$('.tdnum').toggle();return false;">#</a> &nbsp;
+	<a href="#" onclick="$('.tdplatform').toggle();return false;">Platforms</a> &nbsp;
+	<a href="#" onclick="$('.tddrm').toggle();return false;">DRMs</a> &nbsp;
+	<a href="#" onclick="$('.tddate').toggle();return false;">Date Added</a> &nbsp;
+	<a href="#" onclick="$('.tdreview').toggle();return false;">Reviews</a> &nbsp;
+	<a href="#" onclick="$('.tddev').toggle();return false;">Developer</a> &nbsp;
+	<a href="#" onclick="$('.tddesc').toggle();return false;">Description</a> &nbsp;
+	<a href="#" onclick="$('.tdnotes').toggle();return false;">Notes</a></p>
     <table id='gametable'><thead><tr>
         <td id="th_num" class="tdnum">&num;</td>
         <th id="th_game" class="sorttable_alpha">Game</th>
@@ -229,16 +237,7 @@
         <th id="th_desc" class="sorttable_nosort tddesc">Description</th>
         <th id="th_notes" class="sorttable_nosort tdnotes">Notes</th>
     </tr></thead><tbody id="gametablebody"></tbody></table>
-	<p>Toggle: <a href="#" onclick="$('.tdnum').toggle();return false;">#</a>, 
-	<a href="#" onclick="$('.tdplatform').toggle();return false;">Platforms</a>, 
-	<a href="#" onclick="$('.tddrm').toggle();return false;">DRMs</a>, 
-	<a href="#" onclick="$('.tddate').toggle();return false;">Date Added</a>, 
-	<a href="#" onclick="$('.tdreview').toggle();return false;">Reviews</a>, 
-	<a href="#" onclick="$('.tddev').toggle();return false;">Developer</a>, 
-	<a href="#" onclick="$('.tddesc').toggle();return false;">Description</a>, 
-	<a href="#" onclick="$('.tdnotes').toggle();return false;">Notes</a>.</p>
-
-    <!-- <p><a href="http://steamcommunity.com/groups/humble-games">Steam group</a></p> -->
+    <p><a href="http://steamcommunity.com/groups/humble-games">Steam group</a></p>
 </div>
     <script src="scripts/games.js"></script>
     <script>

--- a/table.html
+++ b/table.html
@@ -207,7 +207,7 @@
     <h5>(The game title, developer, and price will still display correctly, but links, DRM, platform, and sorting are broken)<br></h5>
     <br><br><br><br><br><br><br><br><br><br>-->
     <h1>All games from <a href="http://humblebundle.com">the Humble Store</a></h1>
-    <p>All your games are stored on your <a href="https://www.humblebundle.com/home">Humble Bundle account</a>. Feel free to <a href="https://github.com/calvein/humble-games/">edit this list</a>.</p>
+    <p>All your games are stored on your <a href="https://www.humblebundle.com/home">Humble Bundle account</a>. Feel free to <a href="https://github.com/calvein/humble-games/json.html">edit this list</a>.</p>
     <input autofocus placeholder="e.g: &quot;Trine&quot;">
     <p><a href="index.html">Original view with frames</a></p>
     <table id='gametable'><thead><tr>

--- a/table.html
+++ b/table.html
@@ -176,6 +176,10 @@
 	.tdnotes, .tddate {
 		display: none;
 	}
+	
+	.tddrmnosteam {
+		opacity: 0.4;
+	}
     </style>
     <script src="scripts/sorttable.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
@@ -348,10 +352,19 @@
 							tddrmsteamlink.href = 'http://store.steampowered.com/search/?ref=os&term='+tr.dataset.game;
 						}
 						var tddrmsteamimg = document.createElement('img');
-							tddrmsteamimg.src="images/steam.png"
+							tddrmsteamimg.src="images/steam.png";
 						tddrmsteamlink.appendChild(tddrmsteamimg);
 					tddrmsteam.appendChild(tddrmsteamlink);
-                }
+                } else if(tr.dataset.steamurl != "undefined" && tr.dataset.steamurl != null) {
+					var tddrmsteamlink = document.createElement('a');
+						tddrmsteamlink.title="So far as we know, this package doesn't provide a steam key. However, it still has a page on steam. Click here to go to "+tr.dataset.game+" on steam";
+						tddrmsteamlink.href = tr.dataset.steamurl;
+						var tddrmsteamimg = document.createElement('img');
+							tddrmsteamimg.src="images/steam.png";
+							tddrmsteamimg.className="tddrmnosteam";
+						tddrmsteamlink.appendChild(tddrmsteamimg);
+					tddrmsteam.appendChild(tddrmsteamlink);
+				}
             tr.appendChild(tddrmsteam);
 
             var tddrmdesura = document.createElement('td');

--- a/table.html
+++ b/table.html
@@ -224,6 +224,7 @@
         <th id="th_drmfree" class="th_icon tddrm"><span class="drmfree"></span></th>
         <th id="th_ost" class="th_icon"><span class="ost"></span></th>
         <th id="th_review" class="sorttable_alpha tdreview">Review</th>
+        <th id="th_date" class="tdnotes">Notes</th>
         <th id="th_dev" class="sorttable_alpha tddev">Developer</th>
         <th id="th_desc" class="sorttable_nosort tddesc">Description</th>
         <th id="th_notes" class="sorttable_nosort tdnotes">Notes</th>
@@ -446,7 +447,8 @@
 
             var tdnotes = document.createElement('td');
                 tdnotes.className = 'tdnotes';
-                tdnotes.textContent = tr.dataset.notes;
+                if(returnIfExist(tr.dataset.notes) != null && tr.dataset.notes != "undefined")
+					tdnotes.textContent = tr.dataset.notes;
             tr.appendChild(tdnotes);
 
             document.getElementById('gametablebody').appendChild(tr)


### PR DESCRIPTION
Add timestamps to json when using generator, and new (hidden by default) column for the date (someone wanted a way to see what's new since last time, was simple to implement).

Move column options to top.

Change edit link to point to json generator.

Show grayed out steam link if a url has been given but no key is provided.

Show link to steam group at bottom of page.
