### PR TITLE
Add "android": true for Incredipede

### DIFF
--- a/scripts/games.js
+++ b/scripts/games.js
@@ -3709,7 +3709,7 @@ var games = [
         "description": "Purchase Incredipede and get it instantly, cross-platform and DRM-free, and redeemable on Steam!",
         "developer": "Northway Games",
         "platform": {
-            "android": false,
+            "android": true,
             "windows": true,
             "linux": true,
             "mac": true,


### PR DESCRIPTION
Incredipede recently debuted on Android and iOS, and with it, the Humble Store widget added the Android version. Just changing it to true. (Check here: https://www.humblebundle.com/store/incredipede to confirm the Android version is included).
