### PR TITLE
Price correction for Gunpoint: Exclusive Edition

### DIFF
--- a/scripts/games.js
+++ b/scripts/games.js
@@ -3880,7 +3880,7 @@ var games = [
     {
         "name": "Gunpoint: Exclusive Edition",
         "url": "gunpoint_exclusiveedition?preview=djS894h2nS",
-        "price": "20",
+        "price": "30",
         "description": "Pre-order now and get everything in the Special Edition + Making of Gunpoint video, 9 early prototypes, exclusive music tracks, and be on the Secret Beta List!",
         "developer": "Suspicious Developments",
         "platform": {


### PR DESCRIPTION
Price correction for the Exclusive Edition of Gunpoint. Price should be 30, not 20.
